### PR TITLE
fix: Fix bin not found issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.3
+
+#### 🐞 Fixes
+
+- Fixed the "bin not found" errors by uninstalling the toolchain before installing it, if we've detected that it's in a broken state.
+
 ## 0.2.2
 
 #### 🐞 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "rust_plugin"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "extism-pdk",
  "proto_pdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_plugin"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
It looks like rustup can get into a weird state where the toolchain exists, but bins do not. For example:

```
info: syncing channel updates for '1.64.0-aarch64-apple-darwin'

  1.64.0-aarch64-apple-darwin unchanged - (rustc does not exist)

info: checking for self-update
```

If we encounter this, we now force uninstall the toolchain to fix it.