### PR TITLE
new: Install `rustup` if it does not exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.3.0
 
+#### 🚀 Updates
+
+- Will now attempt to install `rustup` if it does not exist on the current machine.
+
 #### 🐞 Fixes
 
 - Will now respect the `RUSTUP_HOME` environment variable when locating the `.rustup` store.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Will now respect the `RUSTUP_HOME` environment variable when locating the `.rustup` store.
 
+#### ⚙️ Internal
+
+- Updated dependencies.
+
 ## 0.2.3
 
 #### 🐞 Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ['cdylib']
 extism-pdk = "0.3.4"
 proto_pdk = { version = "0.7.7" } # , path = "../../proto/crates/pdk" }
 serde = "1.0.188"
-toml = "0.8.0"
+toml = "0.8.1"
 
 [dev-dependencies]
 proto_pdk_test_utils = { version = "0.8.0" } # , path = "../../proto/crates/pdk-test-utils" }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -43,8 +43,38 @@ pub fn native_install(
 ) -> FnResult<Json<NativeInstallOutput>> {
     let env = get_proto_environment()?;
 
-    // Check if rustup is installed (returns `Err` otherwise)
+    // Install rustup if it does not exist
     if !command_exists(&env, "rustup") {
+        // host_log!("Installing rustup");
+
+        // NOTE: this won't work until proto v0.19.1, how to allow it otherwise???
+
+        // let is_windows = env.os.is_windows();
+        // let script_path = PathBuf::from("/proto/temp").join(if is_windows {
+        //     "rustup-init.exe"
+        // } else {
+        //     "rustup-init.sh"
+        // });
+
+        // if !script_path.exists() {
+        //     fs::write(
+        //         &script_path,
+        //         fetch_url_text(if is_windows {
+        //             "https://win.rustup.rs"
+        //         } else {
+        //             "https://sh.rustup.rs"
+        //         })?,
+        //     )?;
+        // }
+
+        // exec_command!(ExecCommandInput {
+        //     command: script_path.to_string_lossy().to_string(),
+        //     args: vec!["--default-toolchain".into(), "none".into(), "-y".into()],
+        //     set_executable: true,
+        //     stream: true,
+        //     ..ExecCommandInput::default()
+        // });
+
         return err!(
             "proto requires `rustup` to be installed and available on PATH to use Rust. Please install it and try again."
         );


### PR DESCRIPTION
This is currently blocked since it requires proto v0.19.1. I'm not sure how to backport this.