### PR TITLE
fix: Explicitly provide the host-triple of the version to install

### DIFF
--- a/src/proto.rs
+++ b/src/proto.rs
@@ -174,7 +174,7 @@ pub fn native_install(
         } else {
             debug!("Detected a broken toolchain, uninstalling it");
 
-            exec_command!(inherit, "rustup", ["toolchain", "uninstall", &channel]);
+            exec_command!(inherit, "rustup", ["toolchain", "uninstall", &triple]);
         }
     }
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -182,7 +182,7 @@ pub fn native_install(
         exec_command!(
             inherit,
             "rustup",
-            ["toolchain", "install", &channel, "--force"]
+            ["toolchain", "install", &triple, "--force"]
         );
     }
 
@@ -197,9 +197,11 @@ pub fn native_install(
 pub fn native_uninstall(
     Json(input): Json<NativeUninstallInput>,
 ) -> FnResult<Json<NativeUninstallOutput>> {
+    let env = get_host_environment()?;
     let channel = get_channel_from_version(&input.context.version);
+    let triple = format!("{}-{}", channel, get_target_triple(&env, NAME)?);
 
-    exec_command!(inherit, "rustup", ["toolchain", "uninstall", &channel]);
+    exec_command!(inherit, "rustup", ["toolchain", "uninstall", &triple]);
 
     Ok(Json(NativeUninstallOutput {
         uninstalled: true,


### PR DESCRIPTION
Rustup has a default-host-triple setting, that may different than the actual host environment. Proto currently don't support these two being different, andit would previously fail to find the executables for the version it had just installed.

While a better solution may to respect Rustup's default-host-triple and support manually specifying the host-triple, this patch at least leaves you with a working installation.

Ran into this because I apparently never ran rustup-init to configure the setting, after installing it on my M1 macbook via Homebrew, so it currently installs x86_64-apple-darwin but Proto looks for aarch64-apple-darwin. 

<details><summary>Error log</summary>
<p>
proto install rust-test 1.76
info: syncing channel updates for '1.76.0-x86_64-apple-darwin'
info: latest update on 2024-02-08, rust version 1.76.0 (07dca489a 2024-02-04)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'rust-docs'
info: downloading component 'rust-std'
info: downloading component 'rustc'
 55.1 MiB /  55.1 MiB (100 %)  30.5 MiB/s in  1s ETA:  0s
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'rust-docs'
 14.7 MiB /  14.7 MiB (100 %)   5.4 MiB/s in  1s ETA:  0s
info: installing component 'rust-std'
 25.3 MiB /  25.3 MiB (100 %)  19.1 MiB/s in  1s ETA:  0s
info: installing component 'rustc'
 55.1 MiB /  55.1 MiB (100 %)  21.3 MiB/s in  2s ETA:  0s
info: installing component 'rustfmt'

  1.76.0-x86_64-apple-darwin installed - (timeout reading rustc version)

info: checking for self-update
Error: proto::execute::missing_file

  × Unable to find an executable for Rust, expected file ~/.rustup/toolchains/1.76.0-aarch64-apple-darwin/bin/cargo does not exist.
</p>
</details> 